### PR TITLE
Result 페이지 구현, Home의 아티스트 관련 기능 추가 등

### DIFF
--- a/src/components/Quiz/QuizItem.tsx
+++ b/src/components/Quiz/QuizItem.tsx
@@ -39,7 +39,8 @@ function QuizItem() {
   };
 
   useEffect(() => {
-    getAlbum('3HqSLMAZ3g3d5poNaI7GOU');
+    const targetId:any = localStorage.getItem('artist-id');
+    getAlbum(targetId);
   }, [question]);
 
   const btnClick = () => {
@@ -60,7 +61,7 @@ function QuizItem() {
       <Progress max={quizLength} value={question} />
       {question >= 0 && question < 3 ? (
         <>
-          <ItemImg src={albumImg} />{' '}
+          {albumImg ? <ItemImg src={albumImg} /> : <LoadingImg>Loading...</LoadingImg>}{' '}
           <ItemTxt>문제 Lorem ipsum dolor sit amet.</ItemTxt>
         </>
       ) : null}
@@ -112,6 +113,18 @@ const ItemImg = styled.img`
   height: 300px;
   border-radius: 5px;
   object-fit: cover;
+`;
+
+const LoadingImg = styled.article`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 300px;
+  height: 300px;
+  background-color: ${PALLETS.WHITE};
+  font-size: 24px;
+  color: ${PALLETS.BLACK};
+  opacity: 0.7;
 `;
 
 const ItemTxt = styled.p`

--- a/src/components/Quiz/QuizItem.tsx
+++ b/src/components/Quiz/QuizItem.tsx
@@ -71,6 +71,7 @@ function QuizItem() {
 
       <BtnWrap>
         <ItemBtn
+          style={{order: Math.ceil(Math.random() * 3)}}
           type="button"
           onClick={() => {
             correctClick();
@@ -79,10 +80,16 @@ function QuizItem() {
         >
           정답
         </ItemBtn>
-        <ItemBtn type="button" onClick={btnClick}>
+        <ItemBtn
+          style={{order: Math.ceil(Math.random() * 3)}}
+          type="button"
+          onClick={btnClick}>
           오답1
         </ItemBtn>
-        <ItemBtn type="button" onClick={btnClick}>
+        <ItemBtn
+          style={{order: Math.ceil(Math.random() * 3)}}
+          type="button"
+          onClick={btnClick}>
           오답2
         </ItemBtn>
       </BtnWrap>

--- a/src/components/Result/ResultContents.tsx
+++ b/src/components/Result/ResultContents.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { PALLETS } from '../../constants';
+import styled from 'styled-components';
+
+function ResultContents({ Point }:any) {
+    const [title, setTitle] = useState<string | null>(null);
+    const [detail, setDetail] = useState<string | null>(null);
+
+    useEffect(():any => {
+        if ( Point = 10 ) {
+            setTitle("이게 되네?");
+            setDetail("10점을 받네요... 축하드립니다👏👏");
+        } else if ( Point >= 8 ) {
+            setTitle("당신을 최고라고 임명함");
+            setDetail("이 사람은 정말 팬심이 대단하다.");
+        } else if ( Point >= 6 ) {
+            setTitle("당신을 쫌 한다고 임명함");
+            setDetail("6점 이상");
+        } else if ( Point >= 4 ) {
+            setTitle("팬심 부족");
+            setDetail("4점 이상");
+        } else if ( Point >= 1 ) {
+            setTitle("그냥 평범한 시민");
+            setDetail("1점 이상");
+        } else if ( Point = 0 ) {
+            setTitle("팬.... 맞죠?");
+            setDetail("0점");
+        }
+    }, [Point]);
+    
+    return (
+    <Wrap>
+        <TitleWrap>{title}</TitleWrap>
+        <DetailWrap>{detail}</DetailWrap>
+    </Wrap>
+    );
+}
+
+const Wrap = styled.div`
+    display: block;
+`;
+
+const TitleWrap = styled.h3`
+    display: block;
+    font-weight: 700;
+    font-size: 47px;
+    color: ${PALLETS.WHITE};
+    text-align: center;
+`;
+const DetailWrap = styled.p`
+    display: block;
+    margin: 25px 0;
+    font-weight: 300;
+    font-size: 22px;
+    color: ${PALLETS.WHITE};
+    text-align: center;
+`;
+
+export default ResultContents;

--- a/src/components/Result/ShareContents.tsx
+++ b/src/components/Result/ShareContents.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { PALLETS } from '../../constants';
+import styled from 'styled-components';
+
+function ShareContents() {
+    const IconType = {
+        kakao: '',
+        facebook: 'https://cdn-icons-png.flaticon.com/512/20/20837.png',
+        twitter: '',
+        instagram: '',
+    }
+    const LinkTo = {
+        kakao: 'https://kakao.com',
+        facebook: 'https://facebook.com',
+        twitter: 'https://twitter.com',
+        instagram: 'https://instagram.com',
+    }
+
+    return (
+    <>
+    <script src="https://kit.fontawesome.com/19d00c3240.js"></script>
+    <ShareButton
+        href={LinkTo.kakao}
+        style={{backgroundImage: IconType.kakao}}
+    />
+    <ShareButton
+        href={LinkTo.facebook}
+        style={{backgroundImage: IconType.facebook}}
+    />
+    <ShareButton
+        href={LinkTo.twitter}
+        style={{backgroundImage: IconType.twitter}}
+    />
+    <ShareButton
+        href={LinkTo.instagram}
+        style={{backgroundImage: IconType.instagram}}
+    />
+    </>
+    );
+}
+
+const ShareButton = styled.a`
+    display: inline-block;
+    margin: 0 6px;
+    width: 45px;
+    height: 45px;
+    border-radius: 100%;
+    background-color: ${PALLETS.WHITE};
+`;
+
+export default ShareContents;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,12 +13,12 @@ function Home() {
   };
 
   return (
-  <HomeWrap>
-    <HomeHeader>
+  <Wrap>
+    <Header>
       <HeaderTitle />
-    </HomeHeader>
+    </Header>
     
-    <HomeMain>
+    <Contents>
       <ArtistWrap onClick={selectArtist}>
         <ArtistBox
           SpotifyID = "3Nrfpe0tUJi4K4DXYWgMUX"
@@ -45,25 +45,23 @@ function Home() {
       <SubmitButton>
         시작
       </SubmitButton>
-    </HomeMain>
+    </Contents>
     
-  </HomeWrap>
+  </Wrap>
   );
 }
 
-const HomeWrap = styled.section`
+const Wrap = styled.section`
   font-family: 'Pretendard';
   height: 100vh;
   background: ${PALLETS.GRAY};
 `;
-const HomeHeader = styled.header`
-  display: flex;
+const Header = styled.header`
   height: 30vh;
-  align-items: flex-end;
   background: ${PALLETS.BLACK};
   color: #fff;
   `;
-const HomeMain = styled.main`
+const Contents = styled.main`
   display: block;
   margin: 10px auto;
   padding: 20px 0;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,7 @@ function Home() {
         <ArtistBox
           SpotifyID = "3Nrfpe0tUJi4K4DXYWgMUX"
           Name = "방탄소년단"
-          ImageLink = "https://lh3.googleusercontent.com/z2Nx3OKs17IJ72sR8tjk124xgfgGJPw80NeOfO9nAvQ34WFWFwqi-ndFQzQKpdZ4rdnGqBH7c0rVTrcaJF4vTHs"
+          ImageLink = "https://i.scdn.co/image/ab6761610000f17882a5d58059f81867b871d8b6"
         />
         <ArtistBox
           SpotifyID = "3HqSLMAZ3g3d5poNaI7GOU"
@@ -50,7 +50,37 @@ function Home() {
         <ArtistBox
           SpotifyID = "7IrDIIq3j04exsiF3Z7CPg"
           Name = "빈지노"
-          ImageLink = "https://w.namu.la/s/62b35913643bf17e02ba500198edf9c964038bdcc76b8b2d420fee20575404babddc8ec64f81add5a964f5dfe56c2ab3f8a72df68f27f357c4bf263d3828d2c19a4a49f8840092c3be410a39adcba265001eb5e8990751d0a97426267bd6b3ad"
+          ImageLink = "https://i.scdn.co/image/ab6761610000f1784cc1f136d0ec448c918f7e6f"
+        />
+        <ArtistBox
+          SpotifyID = "4muJrGMndyYWqZtfk8OWy4"
+          Name = "보아"
+          ImageLink = "https://i.scdn.co/image/ab6761610000f178206c2ba8d14150ccc634765b"
+        />
+        <ArtistBox
+          SpotifyID = "5snNHNlYT2UrtZo5HCJkiw"
+          Name = "에픽하이"
+          ImageLink = "https://i.scdn.co/image/ab6761610000f1787ab6a76808b6f77f5628d231"
+        />
+        <ArtistBox
+          SpotifyID = "4nvFFLtv7ZqoTr83387uK4"
+          Name = "다이나믹듀오"
+          ImageLink = "https://i.scdn.co/image/ab6761610000e5ebf58590979d60df6fb6d6a837"
+        />
+        <ArtistBox
+          SpotifyID = "7f4ignuCJhLXfZ9giKT7rH"
+          Name = "NCT127"
+          ImageLink = "https://i.scdn.co/image/ab6761670000ecd41cfadde11f891e8889b15e4a"
+        />
+        <ArtistBox
+          SpotifyID = "7jFUYMpMUBDL4JQtMZ5ilc"
+          Name = "성시경"
+          ImageLink = "https://i.scdn.co/image/ab6761610000e5ebb3c06b25c1c87dfcec00877d"
+        />
+        <ArtistBox
+          SpotifyID = "1HY2Jd0NmPuamShAr6KMms"
+          Name = "Lady Gaga"
+          ImageLink = "https://i.scdn.co/image/ab6761610000f178749ba770a33230206f8fe159"
         />
       </ArtistWrap>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,15 +1,27 @@
 import React, { useState } from 'react';
-import { PALLETS } from '../constants';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { PALLETS } from '../constants';
 
 import HeaderTitle from '../components/Home/HeaderTitle';
 import ArtistBox from '../components/Home/ArtistBox';
 
 function Home() {
+  const navigate = useNavigate();
   const [selectedArtist, setSelectedArtist] = useState<string>("");
+
   function selectArtist (e: any) {
     const target = e.target.closest('label');
     if (target) {setSelectedArtist(target.dataset.spotifyid);}
+  };
+
+  function goStart() {
+    if (selectedArtist) {
+      navigate('/quiz');
+      localStorage.setItem('artist-id', selectedArtist);
+    } else {
+      window.alert("아티스트를 선택해주세요.");
+    }
   };
 
   return (
@@ -42,7 +54,7 @@ function Home() {
         />
       </ArtistWrap>
 
-      <SubmitButton>
+      <SubmitButton onClick={goStart}>
         시작
       </SubmitButton>
     </Contents>

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,7 +1,92 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { PALLETS } from '../constants';
+import styled, { keyframes } from 'styled-components';
+
+import ResultContents from '../components/Result/ResultContents';
+import ShareContents from '../components/Result/ShareContents';
 
 function Result() {
-  return <div></div>;
+  const Point = 10;
+  
+  return (
+  <Wrap>
+    <Header>
+      <Container>
+        <PointTxt>{Point}</PointTxt>
+        <>정답 수</>
+      </Container>
+    </Header>
+
+    <ContentsWrap>
+      <ResultContents Point={Point} />
+    </ContentsWrap>
+
+    <ShareWrap>
+      <ShareContents />
+    </ShareWrap>
+
+    <Footer>
+      제작
+    </Footer>
+  </Wrap>
+  );
 }
+
+// animation
+const sizeUp = keyframes`
+    0% { font-size: 16px };
+    100% { font-size: 100px };
+`;
+
+const Wrap = styled.section`
+  position: relative;
+  font-family: 'Pretendard';
+  height: 100vh;
+  background: ${PALLETS.GRAY};
+`;
+const Header = styled.header`
+  height: 30vh;
+  background: ${PALLETS.BLACK};
+  color: #fff;
+`;
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 auto;
+  width: 768px;
+  height: 30vh;
+  color: #fff;
+  text-align: center;
+`;
+const PointTxt = styled.span`
+  display: block;
+  margin: 10px 0;
+  font-weight: 700;
+  animation: ${sizeUp} .9s forwards;
+`;
+const ContentsWrap = styled.main`
+  display: block;
+  margin: 10px auto;
+  padding: 20px 0;
+  width: 768px;
+`;
+const ShareWrap = styled.section`
+  margin: 0 auto;
+  margin-top: 50px;
+  width: 768px;
+  text-align: center;
+  `;
+const Footer = styled.footer`
+  position: absolute;
+  margin: 35px auto;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  width: 768px;
+  font-size: 20px;
+  color: #888;
+  text-align: center;
+`;
 
 export default Result;


### PR DESCRIPTION
> ## 수정 사항 요약 📍
> - Result 페이지 UI 구현 (80%)
> - Home의 컴포넌트 이름 통일 리팩토링
> - Home에서 선택한 아티스트를 Quiz에 넘겨주기 (로컬스토리지 활용)
> - Home에 더 많은 아티스트 추가
>
> ## 수정 사항 구체적인 설명
> - Result 페이지 UI 구현, 공유 버튼은 구현 중
> - Home에서 선택한 아티스트를 ``artist-id`` key로 로컬스토리지에 저장 후, Quiz에서 가져오기
>
> ## 기타 질문 🙋🏻
> - 이 부분도 TS스럽게 코드를 짤 방법이 있을까요? (타입 지정이 어렵네요😅)
> ```js
>  useEffect(() => {
>    const targetId:any = localStorage.getItem('artist-id');
>    getAlbum(targetId);
>  }, [question]);
> ```
>
> ## 체크 리스트 ✅
> - [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
> - [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
> - [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
