### PR TITLE
퀴즈 유형 2개 구현, Result에서 정답 갯수 불러오기 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "buffer": "^6.0.3",
         "qs": "^6.10.3",
         "react": "^17.0.2",
+        "react-audio-player": "^0.17.0",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.0",
@@ -13184,6 +13185,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-audio-player": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-audio-player/-/react-audio-player-0.17.0.tgz",
+      "integrity": "sha512-aCZgusPxA9HK7rLZcTdhTbBH9l6do9vn3NorgoDZRxRxJlOy9uZWzPaKjd7QdcuP2vXpxGA/61JMnnOEY7NXeA==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
@@ -25591,6 +25604,14 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.9",
         "whatwg-fetch": "^3.6.2"
+      }
+    },
+    "react-audio-player": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-audio-player/-/react-audio-player-0.17.0.tgz",
+      "integrity": "sha512-aCZgusPxA9HK7rLZcTdhTbBH9l6do9vn3NorgoDZRxRxJlOy9uZWzPaKjd7QdcuP2vXpxGA/61JMnnOEY7NXeA==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "buffer": "^6.0.3",
     "qs": "^6.10.3",
     "react": "^17.0.2",
+    "react-audio-player": "^0.17.0",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",

--- a/src/App.css
+++ b/src/App.css
@@ -8,3 +8,12 @@
   margin: -1px;
   overflow: hidden;
 }
+
+audio::-webkit-media-controls-timeline,
+video::-webkit-media-controls-timeline {
+    display: none;
+}
+audio::-webkit-media-controls-current-time-display,
+audio::-webkit-media-controls-time-remaining-display {
+    display: none;
+}

--- a/src/components/Quiz/QuizItem.tsx
+++ b/src/components/Quiz/QuizItem.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import ReactAudioPlayer from 'react-audio-player';
 import { PALLETS } from '../../constants';
 
 import axios from 'axios';
@@ -14,9 +15,13 @@ function QuizItem() {
   const [correct, setCorrect] = useState<number>(0);
 
   // 앨범의 수록곡 불러오기
-  const [album, setAlbum] = useState({});
+  const [album, setAlbum] = useState<any>({});
+  const [albumName, setAlbumName] = useState<string>('');
+  const [albumRelease, setAlbumRelease] = useState<string>('');
   const [albumImg, setAlbumImg] = useState('');
   const [musicList, setMusicList] = useState([]);
+  const [ranNumsList, setRanNumsList] = useState<number>(0);
+
   const getAlbum = async (artistId: String) => {
     const access_token = await getAuth();
     const albumId = await getArtistAlbum(artistId);
@@ -29,10 +34,10 @@ function QuizItem() {
         },
       });
       setAlbum(res.data);
+      setAlbumName(res.data.name);
+      setAlbumRelease(res.data.release_date);
       setAlbumImg(res.data.images[0].url);
-      setMusicList(res.data.tracks.items);
-      console.log(typeof res.data.images[0].url);
-      console.log(res.data.images[0].url);
+      setMusicList(res.data.tracks.items);   
     } catch (err) {
       console.log(err);
     }
@@ -56,6 +61,16 @@ function QuizItem() {
     setCorrect(correct + 1);
   };
 
+  const playSong = (e:any) => {
+    setTimeout(() => {
+      e.target.currentTime = 999999;
+    }, 400);
+  };
+
+  useEffect(() => {
+    setRanNumsList(Math.ceil(Math.random()*musicList.length));  
+  }, [question])
+  
   return (
     <ItemWrap>
       <Correct>정답 갯수 : {correct}</Correct>
@@ -67,8 +82,31 @@ function QuizItem() {
         </>
       ) : null}
       {question >= 3 && question < 6 ? <></> : null}
-      {question >= 6 && question < 7 ? <></> : null}
-      {question >= 7 && question < 10 ? <></> : null}
+      {question >= 6 && question < 7 ? (
+      <>
+        {albumImg ? <ItemImg src={albumImg} /> : <LoadingImg>Loading...</LoadingImg>}{' '}
+        <QuizWrap>
+          <AlbumNameTxt>{albumName}</AlbumNameTxt>
+          <ItemTxt>이 앨범의 발매연월은?</ItemTxt>
+        </QuizWrap>
+      </>
+      ) : null}
+      {question >= 7 && question < 10 ? (
+        <>
+        <ReactAudioPlayer
+          style={{width: '140px'}}
+          src={musicList[ranNumsList]['preview_url']}
+          onPlay={playSong}
+          autoPlay={false}
+          controls
+        />
+        <ItemTxt>이 노래의 제목은?
+          {"랜덤숫자" + ranNumsList}<br />
+          {musicList[ranNumsList]['preview_url']}<br />
+          {musicList[ranNumsList]['name']}
+        </ItemTxt>
+        </>
+      ) : null}
 
       <BtnWrap>
         <ItemBtn
@@ -79,19 +117,47 @@ function QuizItem() {
             btnClick();
           }}
         >
-          정답
+          {question >= 6 && question < 7 ? (
+          <>
+          {albumRelease.split("-")[0]+"년 " + Number(albumRelease.split("-")[1]) + "월"}
+          </>
+          ) : null}
+          {question >= 7 && question < 10 ? (
+          <>
+          {musicList[ranNumsList]['name']}
+          </>
+          ) : null}
+          (정답)
         </ItemBtn>
         <ItemBtn
           style={{order: Math.ceil(Math.random() * 3)}}
           type="button"
           onClick={btnClick}>
-          오답1
+          {question >= 6 && question < 7 ? (
+          <>
+          {Number(albumRelease.split("-")[0]) + 1 + "년 " + Number(albumRelease.split("-")[1]) + "월"}
+          </>
+          ) : null}
+          {question >= 7 && question < 10 ? (
+          <>
+          {musicList[(ranNumsList > 0 ? ranNumsList - 1 : ranNumsList + 1)]['name']}
+          </>
+          ) : null}
         </ItemBtn>
         <ItemBtn
           style={{order: Math.ceil(Math.random() * 3)}}
           type="button"
           onClick={btnClick}>
-          오답2
+          {question >= 6 && question < 7 ? (
+          <>
+          {albumRelease.split("-")[0] + "년 " + (Number(albumRelease.split("-")[1]) + 1) + "월"}
+          </>
+          ) : null}
+          {question >= 7 && question < 10 ? (
+          <>
+          {musicList[(ranNumsList > 1 ? ranNumsList - 2 : ranNumsList + 2)]['name']}
+          </>
+          ) : null}
         </ItemBtn>
       </BtnWrap>
     </ItemWrap>
@@ -108,6 +174,7 @@ const ItemWrap = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
+  font-family: 'Pretendard';
 `;
 
 const Correct = styled.p`
@@ -137,6 +204,26 @@ const LoadingImg = styled.article`
 
 const ItemTxt = styled.p`
   color: ${PALLETS.WHITE};
+  font-size: 22px;
+  font-weight: 600;
+`;
+
+const QuizWrap = styled.article`
+  text-align: center;
+`;
+
+const AlbumNameTxt = styled.p`
+  display: inline-block;
+  margin-bottom: 12px;
+  padding: 0 10px;
+  background-color: ${PALLETS.BLACK};
+  color: ${PALLETS.WHITE};
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 32px;
+  border: 2px solid ${PALLETS.WHITE};
+  border-radius: 10px;
+  opacity: 0.8;
 `;
 
 const BtnWrap = styled.div`

--- a/src/components/Quiz/QuizItem.tsx
+++ b/src/components/Quiz/QuizItem.tsx
@@ -51,7 +51,7 @@ function QuizItem() {
   const btnClick = () => {
     if (question === quizLength - 1) {
       navigate('/result');
-      localStorage.setItem('corret-amount', String(correct));
+      localStorage.setItem('correct-amount', String(correct));
     } else {
       setQuestion(question + 1);
     }

--- a/src/components/Result/ResultContents.tsx
+++ b/src/components/Result/ResultContents.tsx
@@ -2,31 +2,30 @@ import React, { useEffect, useState } from 'react';
 import { PALLETS } from '../../constants';
 import styled from 'styled-components';
 
-function ResultContents({ Point }:any) {
+function ResultContents() {
     const [title, setTitle] = useState<string | null>(null);
     const [detail, setDetail] = useState<string | null>(null);
+    const myPoint:any = localStorage.getItem('correct-amount');
 
     useEffect(():any => {
-        if ( Point = 10 ) {
-            setTitle("이게 되네?");
-            setDetail("10점을 받네요... 축하드립니다👏👏");
-        } else if ( Point >= 8 ) {
-            setTitle("당신을 최고라고 임명함");
-            setDetail("이 사람은 정말 팬심이 대단하다.");
-        } else if ( Point >= 6 ) {
-            setTitle("당신을 쫌 한다고 임명함");
-            setDetail("6점 이상");
-        } else if ( Point >= 4 ) {
-            setTitle("팬심 부족");
-            setDetail("4점 이상");
-        } else if ( Point >= 1 ) {
-            setTitle("그냥 평범한 시민");
-            setDetail("1점 이상");
-        } else if ( Point = 0 ) {
-            setTitle("팬.... 맞죠?");
-            setDetail("0점");
+        setTitle(PointMsg);
+    }, []);
+
+    function PointMsg ():any {
+        if ( myPoint == 10 ) {
+            return ("이게 되네?");
+        } else if ( myPoint >= 8 ) {
+            return ("당신을 최고라고 임명함");
+        } else if ( myPoint >= 6 ) {
+            return ("당신을 쫌 한다고 임명함");
+        } else if ( myPoint >= 4 ) {
+            return ("팬심 부족");
+        } else if ( myPoint >= 1 ) {
+            return (<>그냥 평범한 시민<br />팬도 아니고 안티도 아닌 당신</>);
+        } else if ( myPoint == 0 ) {
+            return ("팬.... 맞죠?");
         }
-    }, [Point]);
+    };
     
     return (
     <Wrap>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -48,11 +48,6 @@ function Home() {
           ImageLink = "https://pbs.twimg.com/media/FBqo7QvVEAI9fJT.jpg"
         />
         <ArtistBox
-          SpotifyID = "7IrDIIq3j04exsiF3Z7CPg"
-          Name = "빈지노"
-          ImageLink = "https://i.scdn.co/image/ab6761610000f1784cc1f136d0ec448c918f7e6f"
-        />
-        <ArtistBox
           SpotifyID = "4muJrGMndyYWqZtfk8OWy4"
           Name = "보아"
           ImageLink = "https://i.scdn.co/image/ab6761610000f178206c2ba8d14150ccc634765b"
@@ -81,6 +76,11 @@ function Home() {
           SpotifyID = "1HY2Jd0NmPuamShAr6KMms"
           Name = "Lady Gaga"
           ImageLink = "https://i.scdn.co/image/ab6761610000f178749ba770a33230206f8fe159"
+        />
+        <ArtistBox
+          SpotifyID = "2hRQKC0gqlZGPrmUKbcchR"
+          Name = "SHINee"
+          ImageLink = "https://i.scdn.co/image/ab67706c0000da84161330f59573a6b5bb402101"
         />
       </ArtistWrap>
 

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { PALLETS } from '../constants';
 import styled, { keyframes } from 'styled-components';
 
@@ -6,20 +7,30 @@ import ResultContents from '../components/Result/ResultContents';
 import ShareContents from '../components/Result/ShareContents';
 
 function Result() {
-  const Point = localStorage.getItem('correct-amount');
-  
+  const navigate = useNavigate();
+  const myPoint = localStorage.getItem('correct-amount');
+
+  function goHome () {
+    navigate('/');
+  };
+
   return (
   <Wrap>
     <Header>
       <Container>
-        <PointTxt>{Point}</PointTxt>
+        <PointTxt>{myPoint}</PointTxt>
         <>정답 수</>
       </Container>
     </Header>
 
     <ContentsWrap>
-      <ResultContents Point={Point} />
+      <ResultContents />
+
+      <SubmitButton onClick={goHome}>
+          처음으로
+      </SubmitButton>
     </ContentsWrap>
+
 
     <ShareWrap>
       <ShareContents />
@@ -87,6 +98,22 @@ const Footer = styled.footer`
   font-size: 20px;
   color: #888;
   text-align: center;
+`;
+
+const SubmitButton = styled.a`
+  cursor: pointer;
+  display: flex;
+  margin: 0 auto;
+  margin-top: 50px;
+  width: 160px;
+  height: 47px;
+  background-color: ${PALLETS.WHITE};
+  justify-content: center;
+  align-items: center;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 1.76px;
+  border-radius: 100px;
 `;
 
 export default Result;


### PR DESCRIPTION
> ## 수정 사항 요약 📍
> - 퀴즈 유형 2개 (1초 듣기, 발매연월 문제) 구현
> - Result에서 정답 갯수 불러오기 수정
>
> ## 수정 사항 구체적인 설명
> - React-Audio-Player 모듈을 활용해 ``preview_url``을 재생하도록 하고, props-event인 ``onPlay``와 ``setTimeout``을 활용해 특정 시간이 지나면 노래가 정지되도록 구현.
> - 정답 갯수를 LocalStorage에 저장하고 불러오도록 구현
>
> ## 기타 질문 🙋🏻
> - Spotify API에서 불러올 때, 간헐적으로 ``preview_url``이 제대로 불러와지지 않는 문제 발생
>
> ## 체크 리스트 ✅
> - [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
> - [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
> - [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
